### PR TITLE
fix for Qt5 build

### DIFF
--- a/src/src/Plugins/Qt/qt_gui.cpp
+++ b/src/src/Plugins/Qt/qt_gui.cpp
@@ -45,6 +45,9 @@
 #include <QImage>
 #include <QUrl>
 #include <QApplication>
+#if (QT_VERSION < 0x060000)
+#include <QScreen>
+#endif
 
 #include "QTMGuiHelper.hpp"
 #include "QTMWidget.hpp"

--- a/src/src/Plugins/Qt/qt_gui.cpp
+++ b/src/src/Plugins/Qt/qt_gui.cpp
@@ -45,9 +45,7 @@
 #include <QImage>
 #include <QUrl>
 #include <QApplication>
-#if (QT_VERSION < 0x060000)
 #include <QScreen>
-#endif
 
 #include "QTMGuiHelper.hpp"
 #include "QTMWidget.hpp"


### PR DESCRIPTION
Building this branch with Qt5 fails for me with

```
src/src/Plugins/Qt/qt_gui.cpp:195:58: error: invalid use of incomplete type ‘class QScreen’
  195 |   coord2 size = from_qsize (QApplication::primaryScreen()->availableSize());
```

This commit fixes this problem.