### PR TITLE
able to build under msys2 minw64

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -410,7 +410,8 @@ set (TeXmacs_Include_Dirs
   ${TEXMACS_SOURCE_DIR}/src/Plugins
   ${TEXMACS_SOURCE_DIR}/src/Plugins/Pdf/LibAesgm
   ${TEXMACS_SOURCE_DIR}/src/Scheme
-  ${TEXMACS_SOURCE_DIR}/src/Scheme/Guile
+#  ${TEXMACS_SOURCE_DIR}/src/Scheme/Guile
+  ${TEXMACS_SOURCE_DIR}/src/Scheme/S7
   ${TEXMACS_SOURCE_DIR}/src/Scheme/Scheme
   ${TEXMACS_SOURCE_DIR}/src/Style/Environment
   ${TEXMACS_SOURCE_DIR}/src/Style/Evaluate
@@ -441,7 +442,8 @@ else (WIN32)
 endif (WIN32)
 
 set (TeXmacs_Include_Dirs ${TeXmacs_Include_Dirs}
-  ${Guile_INCLUDE_DIRS} ${FREETYPE_INCLUDE_DIRS} ${Cairo_INCLUDE_DIRS}
+  # ${Guile_INCLUDE_DIRS}
+        ${FREETYPE_INCLUDE_DIRS} ${Cairo_INCLUDE_DIRS}
   ${IMLIB2_INCLUDE_DIR} ${GMP_INCLUDES}
 )
 
@@ -454,7 +456,9 @@ file (GLOB_RECURSE TeXmacs_Base_SRCS
   "${TEXMACS_SOURCE_DIR}/src/Graphics/*.cpp"
   "${TEXMACS_SOURCE_DIR}/src/Kernel/*.cpp"
   "${TEXMACS_SOURCE_DIR}/src/Scheme/Scheme/*.cpp"
-  "${TEXMACS_SOURCE_DIR}/src/Scheme/Guile/*.cpp"
+#  "${TEXMACS_SOURCE_DIR}/src/Scheme/Guile/*.cpp"
+  "${TEXMACS_SOURCE_DIR}/src/Scheme/S7/*.cpp"
+  "${TEXMACS_SOURCE_DIR}/src/Scheme/S7/*.c"
   "${TEXMACS_SOURCE_DIR}/src/System/*.cpp"
   "${TEXMACS_SOURCE_DIR}/src/Texmacs/Data/*.cpp"
   "${TEXMACS_SOURCE_DIR}/src/Texmacs/Server/*.cpp"
@@ -537,7 +541,7 @@ set (TeXmacs_MacOS_SRCS
 ### --------------------------------------------------------------------
 
 set (TeXmacs_Libraries
-  ${Guile_LIBRARIES}
+  # ${Guile_LIBRARIES}
   ${ZLIB_LIBRARIES}
   ${JPEG_LIBRARIES}
   ${PNG_LIBRARIES}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -812,3 +812,7 @@ configure_file (${TEXMACS_SOURCE_DIR}/misc/vscode/c_cpp_properties.json.in
 )
 
 message (STATUS "TeXmacs_Libraries" ${TeXmacs_Libraries})
+
+## MINGW packaging
+# copydll.sh and QT_PLUGINS_PATH
+# Also need to copy all scheme source code one directory outside of the binary.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -539,7 +539,6 @@ set (TeXmacs_MacOS_SRCS
 ### --------------------------------------------------------------------
 ### Determine TeXmacs_Libraries
 ### --------------------------------------------------------------------
-
 set (TeXmacs_Libraries
   # ${Guile_LIBRARIES}
   ${ZLIB_LIBRARIES}
@@ -547,6 +546,16 @@ set (TeXmacs_Libraries
   ${PNG_LIBRARIES}
   -lpthread
 )
+
+if (WIN32)
+# explore this
+# CMAKE_INSTALL_UCRT_LIBRARIES
+# I only to manage to get it working for msys2-ucrt.
+set (TeXmacs_Libraries
+  ${TeXmacs_Libraries}
+  wsock32 ws2_32
+)
+endif (WIN32)
 
 if (LINKED_CAIRO)
   set (TeXmacs_Libraries ${TeXmacs_Libraries} ${CAIRO_LIBRARIES})

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -89,7 +89,7 @@ STATIC_TEXMACS: EMPTY_DIRS
 
 @MKGUILE@: tm-guile168
 	cd @DIRGUILE@ && make -j1 && make -j1 install
-	
+
 DEPS: EMPTY_DIRS
 	cd src; $(MAKE) -f makefile deps
 
@@ -510,8 +510,8 @@ WINDOWS_BUNDLE: TEXMACS
 	$(RM) $(WINDOWS_BUILD_BIN_DIR)/texmacs
 	$(MV) $(WINDOWS_BUILD_BIN_DIR)/texmacs.bin $(WINDOWS_BUILD_BIN_DIR)/texmacs.exe
 	if test -n "@SIGNID@"; then @SIGNID@ $(WINDOWS_BUILD_BIN_DIR)/texmacs.exe; fi
-	if test "@XTRA_CMD@" != @'XTRA_CMD'@; then $(CP) -u "@XTRA_CMD@/"* $(WINDOWS_BUILD_BIN_DIR)/; fi
-	if test "@ASPELL_CMD@" != @'ASPELL_CMD'@; then $(CP) -u "@ASPELL_CMD@" $(WINDOWS_BUILD_DIR)/plugins; fi
+	if test "@XTRA_CMD@" == @'XTRA_CMD'@; then $(CP) -u "@XTRA_CMD@/"* $(WINDOWS_BUILD_BIN_DIR)/; fi
+	if test "@ASPELL_CMD@" == @'ASPELL_CMD'@; then $(CP) -u "@ASPELL_CMD@" $(WINDOWS_BUILD_DIR)/plugins; fi
 	if test -x "@GS_EXE@"; then $(CP) @GS_EXE@ $(WINDOWS_BUILD_BIN_DIR)/;fi
 	for f in $(WINDOWS_BUILD_BIN_DIR)/*.exe;do $(WINDOWS_PACKAGE_SRC)/copydll.sh $$f;done
 	$(CP) misc/admin/texmacs_updates_dsa_pub.pem $(WINDOWS_BUILD_DIR)/bin
@@ -621,3 +621,4 @@ VERINFO:
 	svn diff;  }> ${verinfo}
 
 .PHONY: TOUCH STRIP ACCESS_FLAGS
+

--- a/src/README.md
+++ b/src/README.md
@@ -1,3 +1,7 @@
+# Plans
+I want to enable better support for Windows 10 on this branch (mostly fixing up the building process and sometimes add code 
+to provide better experience for Windows users).
+
 # GNU TeXmacs (experimental branch for S7 Scheme)
 
 January 2021.

--- a/src/configure
+++ b/src/configure
@@ -5961,6 +5961,9 @@ $as_echo "#define OS_MINGW (defined (__MINGW__) || defined (__MINGW32__))" >>con
       CONFIG_OS_COMPAT="Windows"
       CPPFLAGS="$CPPFLAGS -I/usr/local/include -IPlugins/Windows -I."
       GUILE_LDFLAGS="-lmingwex $GUILE_LDFLAGS -lintl" #added mingwex to mask the internal guile readdir function
+      # Some Windows libs
+      WIN_LDFLAGS="-lwsock32 -lws2_32 -lucrt"
+      LIBS+=" $WIN_LDFLAGS"
 
   if [[ "-Wl,--stack=16777216" =~ $(echo '^-Wl,') ]]
   then LDFLAGS+=" -Wl,--stack=16777216"
@@ -8428,8 +8431,8 @@ $as_echo "$as_me: WARNING: Drop duplicate flag -I$(pwd)/tm-guile168/build/includ
       GUILE_VERSION=1.6
       GUILE_DATA_PATH=$(pwd)/tm-guile168/build/share/guile/${GUILE_VERSION}
 
-else
-  as_fn_error $? "cannot find guile-config; is Guile installed?" "$LINENO" 5
+# else
+  # as_fn_error $? "cannot find guile-config; is Guile installed?" "$LINENO" 5
 
 fi
 
@@ -8476,8 +8479,8 @@ _ACEOF
 
 
 
-else
-  as_fn_error $? "Guile nor found" "$LINENO" 5
+#else
+ # as_fn_error $? "Guile nor found" "$LINENO" 5
 fi
 
   if test -z "LC_GUILE_use_embedded_guile"; then :

--- a/src/src/Plugins/Qt/qt_gui.cpp
+++ b/src/src/Plugins/Qt/qt_gui.cpp
@@ -72,7 +72,7 @@ Q_IMPORT_PLUGIN(qsvg)
 #endif
 
 #ifdef WIN32 
-Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
+//Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
 #endif
 #ifdef QT_MAC_USE_COCOA
 Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin)
@@ -875,7 +875,7 @@ qt_gui_rep::update () {
   
   time_t delay = delayed_commands.lapse - texmacs_time();
   if (needing_update) delay = 0;
-  else                delay = max (0, min (std_delay, delay));
+  else                delay = max (0, min (std_delay, static_cast<int>(delay)));
   if (postpone_treatment) delay= 9; // NOTE: force occasional display
  
   updatetimer->start (delay);

--- a/src/src/Plugins/Windows/nowide/cstdio.hpp
+++ b/src/src/Plugins/Windows/nowide/cstdio.hpp
@@ -144,7 +144,7 @@ inline DIR* opendir(char const *name)
     return _wopendir (wname.c_str());
 }
 
-inline char* readir_entry(DIR* dir)
+inline string readir_entry(DIR* dir)
 {
   struct _wdirent *wentry;
   wentry = _wreaddir (dir);
@@ -152,14 +152,16 @@ inline char* readir_entry(DIR* dir)
 	     && (0 == wcscmp (wentry->d_name, L".") ||
 		 0 == wcscmp (wentry->d_name, L"..")))
 	     wentry = _wreaddir (dir);
-  if (wentry == NULL) return NULL;
+  if (wentry == NULL) return string("");
   else { 
-  stackstring entry;
+    stackstring entry;
     if(!entry.convert(wentry->d_name) ) {
         errno = EINVAL;
-        return NULL;
+        return string("");
     }
-    else return entry.c_str();
+    else {
+      return string(entry.c_str());
+    }
   }
 } 
 

--- a/src/src/Scheme/S7/s7_tm.cpp
+++ b/src/src/Scheme/S7/s7_tm.cpp
@@ -230,13 +230,15 @@ static tmscm blackbox_to_string (s7_scheme *sc, tmscm args)
   
 static s7_pointer free_blackbox (s7_scheme *sc, s7_pointer obj)
 {
-  // Figure this out. I debug a whole day for this man.
-//  blackbox *ptr = (blackbox *) s7_c_object_value (obj);
-//  tm_delete (ptr);
+  blackbox *ptr = (blackbox *) s7_c_object_value (obj);
+  tm_delete (ptr);
+  // Don't remove this, segmentation error could happen :)
+  return (NULL);
 }
 
 static s7_pointer mark_blackbox (s7_scheme *sc, s7_pointer obj)
 {
+  return (NULL);
 }
 
 static s7_pointer blackbox_is_equal(s7_scheme *sc, s7_pointer args)

--- a/src/src/Scheme/S7/s7_tm.cpp
+++ b/src/src/Scheme/S7/s7_tm.cpp
@@ -230,8 +230,9 @@ static tmscm blackbox_to_string (s7_scheme *sc, tmscm args)
   
 static s7_pointer free_blackbox (s7_scheme *sc, s7_pointer obj)
 {
-  blackbox *ptr = (blackbox *) s7_c_object_value (obj);
-  tm_delete (ptr);
+  // Figure this out. I debug a whole day for this man.
+//  blackbox *ptr = (blackbox *) s7_c_object_value (obj);
+//  tm_delete (ptr);
 }
 
 static s7_pointer mark_blackbox (s7_scheme *sc, s7_pointer obj)
@@ -353,11 +354,11 @@ initialize_scheme () {
   initialize_smobs ();
   initialize_glue ();
   object_stack= s7_name_to_value (tm_s7, "object-stack");
-  
+
     // uncomment to have a guile repl available at startup	
     //	gh_repl(guile_argc, guile_argv);
     //scm_shell (guile_argc, guile_argv);
-  
-  
+
+
 }
 

--- a/src/src/System/Files/file.cpp
+++ b/src/src/System/Files/file.cpp
@@ -520,6 +520,7 @@ read_directory (url u, bool& error_flag) {
   u= resolve (u, "dr");
   if (is_none (u)) return array<string> ();
   string name= concretize (u);
+  // cout << "concretize: " << name << "\n";
 
   // Directory contents in cache?
   if (is_cached ("dir_cache.scm", name) && is_up_to_date (u))
@@ -529,6 +530,7 @@ read_directory (url u, bool& error_flag) {
 
   DIR* dp;
   c_string temp (name);
+  // cout << "converted dir name: " << temp << '\n';
   dp= opendir (temp);
   error_flag= (dp==NULL);
   if (error_flag) return array<string> ();
@@ -536,9 +538,14 @@ read_directory (url u, bool& error_flag) {
   array<string> dir;
   #ifdef OS_MINGW
   while (true) {
-    const char* nextname =  nowide::readir_entry (dp);
-    if (nextname==NULL) break;
-    dir << string (nextname);
+    // const char* nextname =  nowide::readir_entry (dp);
+    string nextname = nowide::readir_entry (dp);
+    // nowide::stackstring dir_entry = nowide::readir_entry (dp);
+    // const char* nextname = dir_entry.c_str();
+    
+    if (N(nextname) == 0) break;
+    dir << nextname;
+    // cout << "nowide::readir_entry() " << dir << '\n';
   #else
   struct dirent* ep;
   while (true) {
@@ -879,9 +886,11 @@ search_sub_dirs (url& all, url root) {
     bool err= false;
     array<string> a= read_directory (root, err);
     if (!err) {
-      for (int i=N(a)-1; i>=0; i--)
+      for (int i=N(a)-1; i>=0; i--) {
+	// cout << "subdirs:" << a[i] << '\n';
         if (N(a[i])>0 && a[i][0] != '.')
           search_sub_dirs (all, root * a[i]);
+      }
     }
     all= root | all;
   }


### PR DESCRIPTION
Hi Max, I was able to build this branch under MSYS2 mingw64 on Windows 10, and hence this pull requst. The patching was minor but took me a long time to figure out. There are still some bugs that are causing Segmentation fault during launch when I enable the optimization flags. I have identified the culprit to be `src/src/Scheme/S7/s7_tm.cpp`. (when I compile this file with "-O0" and all others with "-O3", TeXmacs actually runs fine.) To compile, install MSYS2 and the dependent libs, e.g., 
`pacman -S --noconfirm mingw-w64-x86_64-qt5 base-devel mingw-w64-x86_64-freetype mingw-w64-x86_64-toolchain mingw-w64-x86_64-ntldd-git rsync`.

I also found some issues where TeXmacs cannot export pdf files normally. Not sure if it's only on Windows.

The patching on `readir_entry` is to prevent return of a pointer to a destructed stackstring buffer. This causes TeXmacs to fail to load the default font files.